### PR TITLE
Change maintainer username from @astrofrog-conda-forge to @astrofrog

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,4 +53,4 @@ extra:
   recipe-maintainers:
     - mwcraig
     - bsipocz
-    - astrofrog-conda-forge
+    - astrofrog


### PR DESCRIPTION
This is to update my username from @astrofrog-conda-forge to @astrofrog - I used to have a separate username back when being a member of any conda-forge repository meant that I saw all conda-forge repositories on Travis CI but this is no longer relevant.